### PR TITLE
Add locale query parameter to localized paths

### DIFF
--- a/lib/hotpages/extensions/i18n.rb
+++ b/lib/hotpages/extensions/i18n.rb
@@ -160,15 +160,15 @@ module Hotpages::Extensions::I18n
 
     private
 
-    def localized_current_path(locale)
+    def localized_current_path(locale, suffix: "?locale_selected=1")
       base_path = expanded_base_path(locale: nil)
       base_path.delete_suffix!("index")
 
       # TODO: better handling of base paths
       if site.default_locale?(locale)
-        "/#{base_path}"
+        "/#{base_path}#{suffix}"
       else
-        "/#{locale}/#{base_path}"
+        "/#{locale}/#{base_path}#{suffix}"
       end
     end
   end

--- a/test/dist/expected/index.html
+++ b/test/dist/expected/index.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/index.html
+++ b/test/dist/expected/ja/index.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/misc/htm_extension.htm
+++ b/test/dist/expected/ja/misc/htm_extension.htm
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/misc/htm_extension" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/misc/htm_extension?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/misc/just.html
+++ b/test/dist/expected/ja/misc/just.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/misc/just" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/misc/just?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/misc/markdown.html
+++ b/test/dist/expected/ja/misc/markdown.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/misc/markdown" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/misc/markdown?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/misc/markdown_helper.html
+++ b/test/dist/expected/ja/misc/markdown_helper.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/misc/markdown_helper" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/misc/markdown_helper?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/misc/no_ruby.html
+++ b/test/dist/expected/ja/misc/no_ruby.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/misc/no_ruby" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/misc/no_ruby?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/misc/page_link_patterns.html
+++ b/test/dist/expected/ja/misc/page_link_patterns.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/misc/page_link_patterns" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/misc/page_link_patterns?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/misc/render_hooks.html
+++ b/test/dist/expected/ja/misc/render_hooks.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/misc/render_hooks" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/misc/render_hooks?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/posts/1/bar/index.html
+++ b/test/dist/expected/ja/posts/1/bar/index.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/posts/1/bar/" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/posts/1/bar/?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/posts/1/foo/index.html
+++ b/test/dist/expected/ja/posts/1/foo/index.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/posts/1/foo/" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/posts/1/foo/?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/products.html
+++ b/test/dist/expected/ja/products.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/products" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/products?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/products/about.html
+++ b/test/dist/expected/ja/products/about.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/products/about" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/products/about?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/products/one.html
+++ b/test/dist/expected/ja/products/one.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/products/one" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/products/one?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/ja/products/two.html
+++ b/test/dist/expected/ja/products/two.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>JA</summary><ul><li><a href="/products/two" class="">EN</a></li></ul></details></div>
+  <div><details><summary>JA</summary><ul><li><a href="/products/two?locale_selected=1" class="">EN</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/misc/htm_extension.htm
+++ b/test/dist/expected/misc/htm_extension.htm
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/htm_extension" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/htm_extension?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/misc/just.html
+++ b/test/dist/expected/misc/just.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/just" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/just?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/misc/markdown.html
+++ b/test/dist/expected/misc/markdown.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/markdown" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/markdown?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/misc/markdown_helper.html
+++ b/test/dist/expected/misc/markdown_helper.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/markdown_helper" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/markdown_helper?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/misc/no_ruby.html
+++ b/test/dist/expected/misc/no_ruby.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/no_ruby" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/no_ruby?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/misc/page_link_patterns.html
+++ b/test/dist/expected/misc/page_link_patterns.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/page_link_patterns" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/page_link_patterns?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/misc/render_hooks.html
+++ b/test/dist/expected/misc/render_hooks.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/render_hooks" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/misc/render_hooks?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/posts/1/bar/index.html
+++ b/test/dist/expected/posts/1/bar/index.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/posts/1/bar/" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/posts/1/bar/?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/posts/1/foo/index.html
+++ b/test/dist/expected/posts/1/foo/index.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/posts/1/foo/" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/posts/1/foo/?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/products.html
+++ b/test/dist/expected/products.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/products" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/products?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/products/about.html
+++ b/test/dist/expected/products/about.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/products/about" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/products/about?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/products/one.html
+++ b/test/dist/expected/products/one.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/products/one" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/products/one?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>

--- a/test/dist/expected/products/two.html
+++ b/test/dist/expected/products/two.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <div><details><summary>EN</summary><ul><li><a href="/ja/products/two" class="">JA</a></li></ul></details></div>
+  <div><details><summary>EN</summary><ul><li><a href="/ja/products/two?locale_selected=1" class="">JA</a></li></ul></details></div>
   <header>
     <h1>My Site</h1>
     <nav>


### PR DESCRIPTION
- Updated `localized_current_path` method to append `?locale_selected=1` to localized paths.
- Modified test fixtures to reflect the new query parameter in generated links.